### PR TITLE
Update plugin to discover all the TF files present in CWD by default. Closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install the plugin with [Steampipe](https://steampipe.io):
 steampipe plugin install terraform
 ```
 
-Configure your [config file](https://hub.steampipe.io/plugins/turbot/terraform#configuration).
+Configure your [config file](https://hub.steampipe.io/plugins/turbot/terraform#configuration) to include directories with Terraform configuration files. If no directory is specified, the current working directory will be used.
 
 Run steampipe:
 

--- a/config/terraform.spc
+++ b/config/terraform.spc
@@ -3,7 +3,13 @@ connection "terraform" {
 
   # Paths is a list of locations to search for Terraform configuration files.
   # Wildcard based searches are supported.
-  # Exact file paths can have any name. Wildcard based matches must have an
-  # extension of .tf (case insensitive). Default set to current working directory.
+  # For example:
+  #  - "*" matches all files in a directory.
+  #  - "**" matches all files in a directory, and all the sub-directories in it.
+  #  - "./*" matches all files in current working directory.
+  #  - "../*" matches all files in parent of current working directory.
+  #  - "steampipe*" matches all files starting with "steampipe".
+  # Exact file paths can have any name, i.e. `"/path/to/exact/custom.tf"`.
+  # Default set to current working directory.
   paths = [ "./*.tf" ]
 }

--- a/config/terraform.spc
+++ b/config/terraform.spc
@@ -2,8 +2,8 @@ connection "terraform" {
   plugin = "terraform"
 
   # Paths is a list of locations to search for Terraform configuration files.
-  # Wildcards are supported per https://golang.org/pkg/path/filepath/#Match
+  # Wildcard based searches are supported.
   # Exact file paths can have any name. Wildcard based matches must have an
-  # extension of .tf (case insensitive).
-  # paths = [ "/path/to/dir/*", "/path/to/exact/custom.tf" ]
+  # extension of .tf (case insensitive). Default set to current working directory.
+  paths = [ "./*.tf" ]
 }

--- a/config/terraform.spc
+++ b/config/terraform.spc
@@ -9,7 +9,7 @@ connection "terraform" {
   #  - "./*" matches all files in current working directory.
   #  - "../*" matches all files in parent of current working directory.
   #  - "steampipe*" matches all files starting with "steampipe".
-  # Exact file paths can have any name, i.e. `"/path/to/exact/custom.tf"`.
+  # Exact file paths can have any name, i.e. "/path/to/exact/custom.tf".
   # Default set to current working directory.
   paths = [ "*.tf" ]
 }

--- a/config/terraform.spc
+++ b/config/terraform.spc
@@ -11,5 +11,5 @@ connection "terraform" {
   #  - "steampipe*" matches all files starting with "steampipe".
   # Exact file paths can have any name, i.e. `"/path/to/exact/custom.tf"`.
   # Default set to current working directory.
-  paths = [ "./*.tf" ]
+  paths = [ "*.tf" ]
 }

--- a/config/terraform.spc
+++ b/config/terraform.spc
@@ -1,15 +1,21 @@
 connection "terraform" {
   plugin = "terraform"
 
-  # Paths is a list of locations to search for Terraform configuration files.
-  # Wildcard based searches are supported.
+  # Paths is a list of locations to search for Terraform configuration files
+  # All paths are resolved relative to the current working directory (CWD)
+  # Wildcard based searches are supported, including recursive searches
+
   # For example:
-  #  - "*" matches all files in a directory.
-  #  - "**" matches all files in a directory, and all the sub-directories in it.
-  #  - "./*" matches all files in current working directory.
-  #  - "../*" matches all files in parent of current working directory.
-  #  - "steampipe*" matches all files starting with "steampipe".
-  # Exact file paths can have any name, i.e. "/path/to/exact/custom.tf".
-  # Default set to current working directory.
+  #  - "*.tf" matches all Terraform configuration files in the CWD
+  #  - "**/*.tf" matches all Terraform configuration files in the CWD and all sub-directories
+  #  - "../*.tf" matches all Terraform configuration files in the CWD's parent directory
+  #  - "steampipe*.tf" matches all Terraform configuration files starting with "steampipe" in the current CWD
+  #  - "/path/to/dir/*.tf" matches all Terraform configuration files in a specific directory
+  #  - "/path/to/dir/main.tf" matches a specific file
+
+  # If paths includes "*", all files (including non-Terraform configuration files) in
+  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+
+  # Defaults to CWD
   paths = [ "*.tf" ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,11 +82,11 @@ Installing the latest terraform plugin will create a config file (`~/.steampipe/
 ```hcl
 connection "terraform" {
   plugin = "terraform"
-  paths  = [ "/path/to/your/files/*.tf" ]
+  paths  = [ "./*.tf" ]
 }
 ```
 
-- `paths` - A list of directory paths to search for Terraform files. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match). File matches must have the extension `.tf` (case insensitive).
+- `paths` - A list of directory paths to search for Terraform files. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match). File matches must have the extension `.tf` (case insensitive). Default set to current working directory.
 
 ## Get involved
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ connection "terraform" {
   #  - "./*" matches all files in current working directory.
   #  - "../*" matches all files in parent of current working directory.
   #  - "steampipe*" matches all files starting with "steampipe".
-  # Exact file paths can have any name, i.e. `"/path/to/exact/custom.tf"`.
+  # Exact file paths can have any name, i.e. "/path/to/exact/custom.tf".
   # Default set to current working directory.
   paths = [ "*.tf" ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,21 +83,27 @@ Installing the latest terraform plugin will create a config file (`~/.steampipe/
 connection "terraform" {
   plugin = "terraform"
 
-  # Paths is a list of locations to search for Terraform configuration files.
-  # Wildcard based searches are supported.
+  # Paths is a list of locations to search for Terraform configuration files
+  # All paths are resolved relative to the current working directory (CWD)
+  # Wildcard based searches are supported, including recursive searches
+
   # For example:
-  #  - "*" matches all files in a directory.
-  #  - "**" matches all files in a directory, and all the sub-directories in it.
-  #  - "./*" matches all files in current working directory.
-  #  - "../*" matches all files in parent of current working directory.
-  #  - "steampipe*" matches all files starting with "steampipe".
-  # Exact file paths can have any name, i.e. "/path/to/exact/custom.tf".
-  # Default set to current working directory.
+  #  - "*.tf" matches all Terraform configuration files in the CWD
+  #  - "**/*.tf" matches all Terraform configuration files in the CWD and all sub-directories
+  #  - "../*.tf" matches all Terraform configuration files in the CWD's parent directory
+  #  - "steampipe*.tf" matches all Terraform configuration files starting with "steampipe" in the current CWD
+  #  - "/path/to/dir/*.tf" matches all Terraform configuration files in a specific directory
+  #  - "/path/to/dir/main.tf" matches a specific file
+
+  # If paths includes "*", all files (including non-Terraform configuration files) in
+  # the current CWD will be matched, which may cause errors if incompatible filetypes exist
+
+  # Defaults to CWD
   paths = [ "*.tf" ]
 }
 ```
 
-- `paths` - A list of directory paths to search for Terraform files. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match). File matches must have the extension `.tf` (case insensitive). Default set to current working directory.
+- `paths` - A list of directory paths to search for Terraform files. Paths are resolved relative to the current working directory. Paths may [include wildcards](https://pkg.go.dev/path/filepath#Match) and also support `**` for recursive matching. Defaults to the current working directory.
 
 ## Get involved
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,18 @@ Installing the latest terraform plugin will create a config file (`~/.steampipe/
 ```hcl
 connection "terraform" {
   plugin = "terraform"
-  paths  = [ "./*.tf" ]
+
+  # Paths is a list of locations to search for Terraform configuration files.
+  # Wildcard based searches are supported.
+  # For example:
+  #  - "*" matches all files in a directory.
+  #  - "**" matches all files in a directory, and all the sub-directories in it.
+  #  - "./*" matches all files in current working directory.
+  #  - "../*" matches all files in parent of current working directory.
+  #  - "steampipe*" matches all files starting with "steampipe".
+  # Exact file paths can have any name, i.e. `"/path/to/exact/custom.tf"`.
+  # Default set to current working directory.
+  paths = [ "./*.tf" ]
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ connection "terraform" {
   #  - "steampipe*" matches all files starting with "steampipe".
   # Exact file paths can have any name, i.e. `"/path/to/exact/custom.tf"`.
   # Default set to current working directory.
-  paths = [ "./*.tf" ]
+  paths = [ "*.tf" ]
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/Checkmarx/kics v1.4.9
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/turbot/steampipe-plugin-sdk v1.8.3
 	github.com/zclconf/go-cty v1.10.0
 )
@@ -35,7 +36,6 @@ require (
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.10.1 // indirect
-	github.com/hashicorp/terraform-json v0.13.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/iancoleman/strcase v0.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAw
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=

--- a/terraform/table_terraform_data_source.go
+++ b/terraform/table_terraform_data_source.go
@@ -115,7 +115,7 @@ func listDataSources(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_data_source.listDataSources", "parse_error", err, "path", path)
-			return nil, fmt.Errorf("unsupported file to parse: %s", path)
+			return nil, fmt.Errorf("failed to parse file %s: %v", path, err)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_data_source.go
+++ b/terraform/table_terraform_data_source.go
@@ -115,7 +115,7 @@ func listDataSources(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_data_source.listDataSources", "parse_error", err, "path", path)
-			return nil, err
+			return nil, fmt.Errorf("unsupported file to parse: %s", path)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_local.go
+++ b/terraform/table_terraform_local.go
@@ -74,7 +74,7 @@ func listLocals(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_local.listLocals", "parse_error", err, "path", path)
-			return nil, err
+			return nil, fmt.Errorf("unsupported file to parse: %s", path)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_local.go
+++ b/terraform/table_terraform_local.go
@@ -74,7 +74,7 @@ func listLocals(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_local.listLocals", "parse_error", err, "path", path)
-			return nil, fmt.Errorf("unsupported file to parse: %s", path)
+			return nil, fmt.Errorf("failed to parse file %s: %v", path, err)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_output.go
+++ b/terraform/table_terraform_output.go
@@ -97,7 +97,7 @@ func listOutputs(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_output.listOutputs", "parse_error", err, "path", path)
-			return nil, err
+			return nil, fmt.Errorf("unsupported file to parse: %s", path)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_output.go
+++ b/terraform/table_terraform_output.go
@@ -97,7 +97,7 @@ func listOutputs(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_output.listOutputs", "parse_error", err, "path", path)
-			return nil, fmt.Errorf("unsupported file to parse: %s", path)
+			return nil, fmt.Errorf("failed to parse file %s: %v", path, err)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_provider.go
+++ b/terraform/table_terraform_provider.go
@@ -88,7 +88,7 @@ func listProviders(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_provider.listProviders", "parse_error", err, "path", path)
-			return nil, err
+			return nil, fmt.Errorf("unsupported file to parse: %s", path)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_provider.go
+++ b/terraform/table_terraform_provider.go
@@ -88,7 +88,7 @@ func listProviders(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_provider.listProviders", "parse_error", err, "path", path)
-			return nil, fmt.Errorf("unsupported file to parse: %s", path)
+			return nil, fmt.Errorf("failed to parse file %s: %v", path, err)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_resource.go
+++ b/terraform/table_terraform_resource.go
@@ -123,7 +123,7 @@ func listResources(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_resource.listResources", "parse_error", err, "path", path)
-			return nil, err
+			return nil, fmt.Errorf("unsupported file to parse: %s", path)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/table_terraform_resource.go
+++ b/terraform/table_terraform_resource.go
@@ -123,7 +123,7 @@ func listResources(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
 		if err != nil {
 			plugin.Logger(ctx).Error("terraform_resource.listResources", "parse_error", err, "path", path)
-			return nil, fmt.Errorf("unsupported file to parse: %s", path)
+			return nil, fmt.Errorf("failed to parse file %s: %v", path, err)
 		}
 
 		for _, doc := range parsedDocs.Docs {

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -87,6 +87,17 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 
 	// Sanitize the matches to likely Terraform files
 	for _, i := range matches {
+		// Check file or directory
+		fileInfo, err := os.Stat(i)
+		if err != nil {
+			plugin.Logger(ctx).Error("fileList", "error reading file path", err)
+			return nil, err
+		}
+
+		// Ignore, if given path is a directory
+		if fileInfo.IsDir() {
+			continue
+		}
 
 		// If the file path is an exact match to a matrix path then it's always
 		// treated as a match - it was requested exactly
@@ -101,13 +112,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 			d.StreamListItem(ctx, filePath{Path: i})
 			continue
 		}
-
-		// This file was expanded from the glob, so check it's likely to be
-		// of the right type based on the extension.
-		ext := filepath.Ext(i)
-		if ext == ".tf" {
-			d.StreamListItem(ctx, filePath{Path: i})
-		}
+		d.StreamListItem(ctx, filePath{Path: i})
 	}
 
 	return nil, nil

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -57,7 +57,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 			// File system context
 			home, err := os.UserHomeDir()
 			if err != nil {
-				plugin.Logger(ctx).Error("tfConfigList", "os.UserHomeDir error. ~ will not be expanded in paths.", err)
+				plugin.Logger(ctx).Error("utils.tfConfigList", "os.UserHomeDir error. ~ will not be expanded in paths.", err)
 			}
 
 			// Resolve ~ to home dir
@@ -73,7 +73,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// Get full path
 		fullPath, err := filepath.Abs(i)
 		if err != nil {
-			plugin.Logger(ctx).Error("tfConfigList", "failed to fetch absolute path", err)
+			plugin.Logger(ctx).Error("utils.tfConfigList", "failed to fetch absolute path", err, "path", i)
 			return nil, err
 		}
 
@@ -87,14 +87,14 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 
 	// Sanitize the matches to likely Terraform files
 	for _, i := range matches {
-		// Check file or directory
+		// Check if file or directory
 		fileInfo, err := os.Stat(i)
 		if err != nil {
-			plugin.Logger(ctx).Error("tfConfigList", "error reading file path", err)
+			plugin.Logger(ctx).Error("utils.tfConfigList", "error getting file info", err, "path", i)
 			return nil, err
 		}
 
-		// Ignore, if given path is a directory
+		// Ignore directories
 		if fileInfo.IsDir() {
 			continue
 		}

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -90,7 +90,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// Check file or directory
 		fileInfo, err := os.Stat(i)
 		if err != nil {
-			plugin.Logger(ctx).Error("fileList", "error reading file path", err)
+			plugin.Logger(ctx).Error("tfConfigList", "error reading file path", err)
 			return nil, err
 		}
 


### PR DESCRIPTION
Updates:
- Update `paths` default to `["*.tf"]`, so TF files in the current directory are loaded (non-recursively)
- `paths` arg is no longer commented out by default
- Add support for `~` expansion in `paths`
- Add support for `**` to support matching recursively
- Remove file extension matching when using wildcards, e.g., if `paths = [ "*" ]`, files not ending in `.tf` will be loaded as well, which would cause a parsing error
- The plugin will still fail to initialize if `paths` is not defined (as a warning to users)