### PR TITLE
Add table terraform_module

### DIFF
--- a/docs/tables/terraform_module.md
+++ b/docs/tables/terraform_module.md
@@ -17,7 +17,7 @@ select
   source,
   version
 from
-  terraform_module
+  terraform_module;
 ```
 
 ### List all modules that reference a source on 'gitlab.com' but don't use a version number as reference
@@ -26,6 +26,9 @@ from
 select
   name,
   split_part(source,'=',-1) as ref
-from terraform_module
-where source like '%gitlab.com%' and not split_part(source,'=',-1) ~ '^[0-9]'
+from
+  terraform_module
+where
+  source like '%gitlab.com%'
+  and not split_part(source,'=',-1) ~ '^[0-9]';
 ```

--- a/docs/tables/terraform_module.md
+++ b/docs/tables/terraform_module.md
@@ -3,7 +3,8 @@
 Modules are containers for multiple resources that are used together.
 
 The `source` argument in a module block tells Terraform where to find
-the source code for the desired child module.
+the source code for the desired child module. Due to name clashes, the
+column name for the `source` argument is `module_source`.
 
 Registry modules support versioning via the `version` argument.
 
@@ -14,7 +15,7 @@ Registry modules support versioning via the `version` argument.
 ```sql
 select
   name,
-  source,
+  module_source,
   version
 from
   terraform_module;
@@ -25,10 +26,10 @@ from
 ```sql
 select
   name,
-  split_part(source,'=',-1) as ref
+  split_part(module_source,'=',-1) as ref
 from
   terraform_module
 where
-  source like '%gitlab.com%'
-  and not split_part(source,'=',-1) ~ '^[0-9]';
+  module_source like '%gitlab.com%'
+  and not split_part(module_source,'=',-1) ~ '^[0-9]';
 ```

--- a/docs/tables/terraform_module.md
+++ b/docs/tables/terraform_module.md
@@ -1,0 +1,31 @@
+# Table: terraform_module
+
+Modules are containers for multiple resources that are used together.
+
+The `source` argument in a module block tells Terraform where to find
+the source code for the desired child module.
+
+Registry modules support versioning via the `version` argument.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  source,
+  version
+from
+  terraform_module
+```
+
+### List all modules that reference a source on 'gitlab.com' but don't use a version number as reference
+
+```sql
+select
+  name,
+  split_part(source,'=',-1) as ref
+from terraform_module
+where source like '%gitlab.com%' and not split_part(source,'=',-1) ~ '^[0-9]'
+```

--- a/terraform/plugin.go
+++ b/terraform/plugin.go
@@ -30,6 +30,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"terraform_output":      tableTerraformOutput(ctx),
 			"terraform_provider":    tableTerraformProvider(ctx),
 			"terraform_resource":    tableTerraformResource(ctx),
+			"terraform_module":      tableTerraformModule(ctx),
 		},
 	}
 

--- a/terraform/plugin.go
+++ b/terraform/plugin.go
@@ -27,10 +27,10 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		TableMap: map[string]*plugin.Table{
 			"terraform_data_source": tableTerraformDataSource(ctx),
 			"terraform_local":       tableTerraformLocal(ctx),
+			"terraform_module":      tableTerraformModule(ctx),
 			"terraform_output":      tableTerraformOutput(ctx),
 			"terraform_provider":    tableTerraformProvider(ctx),
 			"terraform_resource":    tableTerraformResource(ctx),
-			"terraform_module":      tableTerraformModule(ctx),
 		},
 	}
 

--- a/terraform/table_terraform_module.go
+++ b/terraform/table_terraform_module.go
@@ -40,7 +40,7 @@ func tableTerraformModule(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "variables",
+				Name:        "arguments",
 				Description: "Input variables passed to this module.",
 				Type:        proto.ColumnType_JSON,
 			},

--- a/terraform/table_terraform_module.go
+++ b/terraform/table_terraform_module.go
@@ -41,7 +41,7 @@ func tableTerraformModule(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "arguments",
-				Description: "Input variables passed to this module.",
+				Description: "Input arguments passed to this module.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{

--- a/terraform/table_terraform_module.go
+++ b/terraform/table_terraform_module.go
@@ -1,0 +1,135 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/Checkmarx/kics/pkg/model"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+func tableTerraformModule(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "terraform_module",
+		Description: "Terraform module information.",
+		List: &plugin.ListConfig{
+			ParentHydrate: tfConfigList,
+			Hydrate:       listModules,
+			KeyColumns:    plugin.OptionalColumns([]string{"path"}),
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "Module name.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "source",
+				Description: "Module source",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "version",
+				Description: "Module version",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "start_line",
+				Description: "Starting line number.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "path",
+				Description: "Path to the file.",
+				Type:        proto.ColumnType_STRING,
+			},
+		},
+	}
+}
+
+type terraformModule struct {
+	Name      string
+	Path      string
+	StartLine int
+	Source    string
+	Version   string
+}
+
+func listModules(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// The path comes from a parent hydrate, defaulting to the config paths
+	// or available by the optional key column
+	path := h.Item.(filePath).Path
+
+	combinedParser, err := Parser()
+	if err != nil {
+		plugin.Logger(ctx).Error("terraform_module.listModules", "create_parser_error", err)
+		return nil, err
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		plugin.Logger(ctx).Error("terraform_module.listModules", "read_file_error", err, "path", path)
+		return nil, err
+	}
+
+	var tfModule terraformModule
+
+	for _, parser := range combinedParser {
+		parsedDocs, err := ParseContent(ctx, d, path, content, parser)
+		if err != nil {
+			plugin.Logger(ctx).Error("terraform_module.listModules", "parse_error", err, "path", path)
+			return nil, fmt.Errorf("failed to parse file %s: %v", path, err)
+		}
+
+		for _, doc := range parsedDocs.Docs {
+			if doc["module"] != nil {
+				for moduleName, moduleData := range doc["module"].(model.Document) {
+					tfModule, err = buildModule(ctx, path, moduleName, moduleData.(model.Document))
+					if err != nil {
+						plugin.Logger(ctx).Error("terraform_module.listModules", "build_module_error", err)
+						return nil, err
+					}
+					d.StreamListItem(ctx, tfModule)
+				}
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func buildModule(_ context.Context, path string, name string, d model.Document) (terraformModule, error) {
+	var tfModule terraformModule
+
+	tfModule.Path = path
+	tfModule.Name = name
+
+	// The starting line number is stored in "_kics__default"
+	kicsLines := d["_kics_lines"]
+	linesMap := kicsLines.(map[string]model.LineObject)
+	defaultLine := linesMap["_kics__default"]
+	tfModule.StartLine = defaultLine.Line
+
+	// Remove all "_kics" arguments
+	sanitizeDocument(d)
+
+	for k, v := range d {
+		switch k {
+		case "source":
+			if reflect.TypeOf(v).String() != "string" {
+				return tfModule, fmt.Errorf("The 'source' argument for module '%s' must be of type string", name)
+			}
+			tfModule.Source = v.(string)
+
+		case "version":
+			if reflect.TypeOf(v).String() != "string" {
+				return tfModule, fmt.Errorf("The 'version' argument for module '%s' must be of type string", name)
+			}
+			tfModule.Version = v.(string)
+		}
+	}
+	return tfModule, nil
+}


### PR DESCRIPTION
Add an additional table for terraform_module as tracked here #14 

## Example query results

`steampipe query "select name, source, version from terraform_module"`

```text
+----------+------------------------------------+---------+
| name     | source                             | version |
+----------+------------------------------------+---------+
| eks      | terraform-aws-modules/eks/aws      | 18.7.2  |
| key_pair | terraform-aws-modules/key-pair/aws | 1.0.1   |
| eks_env  | cloudposse/label/null              | 0.25.0  |
+----------+------------------------------------+---------+
```

* as for the integration test logs etc: happy to provide / look into if somebody could advice what exactly is wanted.
