### PR TITLE
Fix invalid memory address issue for arguments interface and Handle the error when the specified path is unavailable

### DIFF
--- a/terraform/table_terraform_resource.go
+++ b/terraform/table_terraform_resource.go
@@ -217,7 +217,7 @@ func buildResource(ctx context.Context, isTFFilePath bool, content []byte, path 
 	tfResource.Arguments = make(map[string]interface{})
 	tfResource.Lifecycle = make(map[string]interface{})
 	tfResource.Instances = make(map[string]interface{})
-
+	plugin.Logger(ctx).Error("document:::", d)
 	// Remove all "_kics" arguments
 	sanitizeDocument(d)
 

--- a/terraform/table_terraform_resource.go
+++ b/terraform/table_terraform_resource.go
@@ -217,7 +217,7 @@ func buildResource(ctx context.Context, isTFFilePath bool, content []byte, path 
 	tfResource.Arguments = make(map[string]interface{})
 	tfResource.Lifecycle = make(map[string]interface{})
 	tfResource.Instances = make(map[string]interface{})
-	plugin.Logger(ctx).Error("document:::", d)
+
 	// Remove all "_kics" arguments
 	sanitizeDocument(d)
 

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -79,12 +79,12 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
+			plugin.Logger(ctx).Error("tfConfigList.configurationFilePaths.GetSourceFiles", err)
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
 				return nil, nil
 			}
-			plugin.Logger(ctx).Error("GetSourceFiles", err)
 			return nil, err
 		}
 		matches = append(matches, files...)
@@ -108,11 +108,12 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
+			plugin.Logger(ctx).Error("tfConfigList.planFilePaths.GetSourceFiles", err)
+
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
 				return nil, nil
 			}
-			plugin.Logger(ctx).Error("GetSourceFiles", err)
 			return nil, err
 		}
 		matchedPlanFilePaths = append(matchedPlanFilePaths, files...)
@@ -139,12 +140,12 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
+			plugin.Logger(ctx).Error("tfConfigList.stateFilePaths.GetSourceFiles", err)
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
 				return nil, nil
 			}
-			plugin.Logger(ctx).Error("GetSourceFiles", err)
 			return nil, err
 		}
 		matchedStateFilePaths = append(matchedStateFilePaths, files...)

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -79,7 +79,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
-			plugin.Logger(ctx).Error("tfConfigList.configurationFilePaths.GetSourceFiles", err)
+			plugin.Logger(ctx).Error("tfConfigList.configurationFilePaths", "get_source_files_error", err)
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
@@ -108,7 +108,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
-			plugin.Logger(ctx).Error("tfConfigList.planFilePaths.GetSourceFiles", err)
+			plugin.Logger(ctx).Error("tfConfigList.planFilePaths", "get_source_files_error", err)
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
@@ -140,7 +140,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
-			plugin.Logger(ctx).Error("tfConfigList.stateFilePaths.GetSourceFiles", err)
+			plugin.Logger(ctx).Error("tfConfigList.stateFilePaths", "get_source_files_error", err)
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -168,15 +168,18 @@ func sanitizeDocument(d model.Document) {
 			delete(d, k)
 		}
 
-		if reflect.TypeOf(v).String() == "model.Document" {
-			sanitizeDocument(v.(model.Document))
-		}
+		// check if the arguments interface is nil
+		if v != nil {
+			if reflect.TypeOf(v).String() == "model.Document" {
+				sanitizeDocument(v.(model.Document))
+			}
 
-		// Some map arguments are returned as "[]interface {}" types from the parser
-		if reflect.TypeOf(v).String() == "[]interface {}" {
-			for _, v := range v.([]interface{}) {
-				if reflect.TypeOf(v).String() == "model.Document" {
-					sanitizeDocument(v.(model.Document))
+			// Some map arguments are returned as "[]interface {}" types from the parser
+			if reflect.TypeOf(v).String() == "[]interface {}" {
+				for _, v := range v.([]interface{}) {
+					if reflect.TypeOf(v).String() == "model.Document" {
+						sanitizeDocument(v.(model.Document))
+					}
 				}
 			}
 		}

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -79,6 +79,12 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
+
+			// If the specified path is unavailable, then an empty row should populate
+			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
+				return nil, nil
+			}
+			plugin.Logger(ctx).Error("GetSourceFiles", err)
 			return nil, err
 		}
 		matches = append(matches, files...)
@@ -102,6 +108,11 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
+			// If the specified path is unavailable, then an empty row should populate
+			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
+				return nil, nil
+			}
+			plugin.Logger(ctx).Error("GetSourceFiles", err)
 			return nil, err
 		}
 		matchedPlanFilePaths = append(matchedPlanFilePaths, files...)
@@ -128,6 +139,12 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		// List the files in the given source directory
 		files, err := d.GetSourceFiles(i)
 		if err != nil {
+
+			// If the specified path is unavailable, then an empty row should populate
+			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
+				return nil, nil
+			}
+			plugin.Logger(ctx).Error("GetSourceFiles", err)
 			return nil, err
 		}
 		matchedStateFilePaths = append(matchedStateFilePaths, files...)


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
In a particular document, some property values can be null; like in the below document, tags and timeouts are null.

document:::: EXTRA_VALUE_AT_END="map[_kics_lines:map[_kics__default:map[_kics_line:21] _kics_description:map[_kics_line:22] _kics_ingress:map[_kics_arr:[map[_kics__default:map[_kics_line:25] _kics_cidr_blocks:map[_kics_arr:[map[_kics__default:map[_kics_line:26]]] _kics_line:25] _kics_description:map[_kics_line:28] _kics_from_port:map[_kics_line:29] _kics_ipv6_cidr_blocks:map[_kics_line:30] _kics_prefix_list_ids:map[_kics_line:33] _kics_protocol:map[_kics_line:36] _kics_security_groups:map[_kics_line:37] _kics_self:map[_kics_line:40] _kics_to_port:map[_kics_line:41]]] _kics_line:23] _kics_name:map[_kics_line:44] _kics_revoke_rules_on_delete:map[_kics_line:45] _kics_tags:map[_kics_line:46] _kics_timeouts:map[_kics_line:47]] description:Example Security Group ingress:[map[cidr_blocks:[0.0.0.0/0] description: from_port:22 ipv6_cidr_blocks:[] prefix_list_ids:[] protocol:tcp security_groups:[] self:false to_port:22]] name:example_sg revoke_rules_on_delete:false tags:<nil> timeouts:<nil>]"


> select name, type, mode, path from terraform_resource
+------------+--------------------+--------+-----------------------------------------------------------+
| name       | type               | mode   | path                                                      |
+------------+--------------------+--------+-----------------------------------------------------------+
| example_sg | aws_security_group | <null> | /Users/sourav/turbot/steampipe-plugin-terraform/plan.json |
+------------+--------------------+--------+-----------------------------------------------------------+
```
</details>
