### PR TITLE
Fixed plugin to correctly non-existent file paths in config file

### DIFF
--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -83,7 +83,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
-				return nil, nil
+				continue
 			}
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
-				return nil, nil
+				continue
 			}
 			return nil, err
 		}
@@ -144,7 +144,7 @@ func tfConfigList(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 
 			// If the specified path is unavailable, then an empty row should populate
 			if strings.Contains(err.Error(), "failed to get directory specified by the source") {
-				return nil, nil
+				continue
 			}
 			return nil, err
 		}


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select * from terraform_resource
+---------+----------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------->
| name    | type           | mode   | arguments                                                                                                                                             >
+---------+----------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------->
| example | aws_ebs_volume | <null> | {"availability_zone":"us-west-2a","final_snapshot":false,"multi_attach_enabled":null,"outpost_arn":null,"size":40,"tags":{"Name":"HelloWorld","_kics_l>
+---------+----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>
