### PR TITLE
Fix the plugin's connection config variable reference to use hcl syntax

### DIFF
--- a/terraform/connection_config.go
+++ b/terraform/connection_config.go
@@ -5,10 +5,10 @@ import (
 )
 
 type terraformConfig struct {
-	ConfigurationFilePaths []string `cty:"configuration_file_paths" steampipe:"watch"`
-	Paths                  []string `cty:"paths" steampipe:"watch"`
-	PlanFilePaths          []string `cty:"plan_file_paths" steampipe:"watch"`
-	StateFilePaths         []string `cty:"state_file_paths" steampipe:"watch"`
+	ConfigurationFilePaths []string `hcl:"configuration_file_paths" steampipe:"watch"`
+	Paths                  []string `hcl:"paths" steampipe:"watch"`
+	PlanFilePaths          []string `hcl:"plan_file_paths" steampipe:"watch"`
+	StateFilePaths         []string `hcl:"state_file_paths" steampipe:"watch"`
 }
 
 func ConfigInstance() interface{} {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
